### PR TITLE
RFC: Added error when setting bp in unknow file.

### DIFF
--- a/src/breakfile.jl
+++ b/src/breakfile.jl
@@ -122,11 +122,16 @@ end
 
 function breakpoint(file::AbstractString, line::Int)
     bp = Breakpoint()
+    found = false
     for (fname, meths) in filemap
         contains(string(fname), file) || continue
+        found = true
         for meth in methods_for_line(meths, line)
             add_meth_to_bp!(bp, meth)
         end
+    end
+    if !found
+        warn("No file $file found in loaded packages or included files.")
     end
     unshift!(bp.sources, FileLineSource(bp, file, line))
     bp


### PR DESCRIPTION
Currently no error is thrown when adding a break-point to a unknown file:
```
julia> using Gallium

julia> bp = breakpoint("/tmp/non-existant.jl", 2)
Locations (+: active, -: inactive, *: source):
 * Any method reaching /tmp/non-existant.jl:2
```

With this Pr:
```
julia> bp = breakpoint("/tmp/non-existant.jl", 2)
ERROR: No file /tmp/non-existant.jl found in loaded packages or included files.
 in breakpoint(::String, ::Int64) at /home/mauro/.julia/v0.5/Gallium/src/breakfile.jl:134
 in eval(::Module, ::Any) at ./boot.jl:234
 in macro expansion at ./REPL.jl:92 [inlined]
 in (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:46
```

If this is a desired feature, I can add tests.