### PR TITLE
Get rid of most warnings due to deprecated bindings

### DIFF
--- a/src/breakfile.jl
+++ b/src/breakfile.jl
@@ -19,6 +19,7 @@ function initial_sweep()
         mod = pop!(workqueue)
         for sym in names(mod, true)
             !isdefined(mod, sym) && continue
+            Base.isdeprecated(mod, sym) && continue
             x = getfield(mod, sym)
             if isa(x, Core.Module)
                 !(x in visited_modules) && push!(workqueue, x)

--- a/src/x86_64/registers.jl
+++ b/src/x86_64/registers.jl
@@ -26,7 +26,7 @@ module X86_64
 
   const gdb_numbering = Dict{Int, Symbol}(
      0 => :rax, 1 => :rbx, 2 => :rcx, 3 => :rdx,
-     4 => :rsi, [i=>dwarf_numbering[i] for i in 5:16]...
+     4 => :rsi, Dict(i=>dwarf_numbering[i] for i in 5:16)...
   )
   const inverse_gdb = map(p->p[2]=>p[1], gdb_numbering)
 


### PR DESCRIPTION
This is the one I was after, and wow was it annoying to find. Note to self: use `flush` religiously when trying to figure out which line is issuing a warning.

High time to tag a new release, too.